### PR TITLE
Run unit tests on PRs and pushes to d2iq/* branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,24 @@
+name: Test
+on:
+  push:
+    branches:
+      - d2iq/*
+  pull_request:
+    branches:
+      - d2iq/*
+
+jobs:
+  test:
+    name: Test
+    runs-on: 
+      - self-hosted
+      - small
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+          cache: true # cache go action in github actions cache store.
+      - name: make test
+        run: make test


### PR DESCRIPTION
We'll use d2iq/main as our fork's main branch, and the d2iq/ prefix for any release branches. This workflow will build and run unit tests on any PRs or pushes to these branches.