### PR TITLE
build: Fix kustomize path

### DIFF
--- a/d2iq.Makefile
+++ b/d2iq.Makefile
@@ -22,10 +22,11 @@ docker-buildx-builder:
 
 # The upstream 'release-manifests' target does not correctly override the image.
 # We work around this by using `kustomize edit set image`.
-release-manifests: kustomize
-	mkdir -p $(MANIFEST_DIR)
-	cd config/manager && $(KUSTOMIZE) edit set image projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director=$(REGISTRY)/$(CAPVCD_IMG):$(VERSION)
-	$(KUSTOMIZE) build config/default > $(MANIFEST_DIR)/infrastructure-components.yaml
+release-manifests: $(KUSTOMIZE)
+	mkdir -p templates && \
+	cd config/manager && \
+		$(GITROOT)/$(KUSTOMIZE) edit set image projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director=$(REGISTRY)/$(CAPVCD_IMG):$(VERSION)
+	$(GITROOT)/$(KUSTOMIZE) build config/default > templates/infrastructure-components.yaml
 
 .PHONY: build-within-docker
 build-within-docker: vendor


### PR DESCRIPTION
Previously, the path was absolute, and kustomize could be run from config/manager. A recent upstream change made the path relative. This makes the path absolute again.
