### PR TITLE
fix: Regex should account for tag version string correctly.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - v*-d2iq.*
+      - v.*-d2iq.*
 
 # Because variables are not exported, they are not visible by child processes, e.g. make
 env:


### PR DESCRIPTION
## Description

Release Workflow regex currently doesn't match d2iq tags. This can be verified:
- [Current version here](https://regex101.com/r/yC7AAI/1) 
- [Fixed version here](https://regex101.com/r/N3UDEk/1)

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [x] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [x] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [x] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #
