### PR TITLE
fix: Ensure localhost maps to IPv4 address

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -40,8 +40,18 @@ write_files:
       # Exit on the first error. Does not apply to commad lists, or pipelines.
       set -o errexit
 
-      # Our images do not require any network customization,
-      # but CAPVCD requires a successful status to finish bootstrapping.
+      # Begin network configuration
+      vmtoolsd --cmd "info-set guestinfo.postcustomization.networkconfiguration.status in_progress"
+      # Disable IPv6. CAPVCD does not yet support it.
+      echo '# Added by CAPVCD bootstrap' >> /etc/sysctl.conf
+      echo 'net.ipv6.conf.all.disable_ipv6 = 1' >> /etc/sysctl.conf
+      echo 'net.ipv6.conf.default.disable_ipv6 = 1' >> /etc/sysctl.conf
+      echo 'net.ipv6.conf.lo.disable_ipv6 = 1' >> /etc/sysctl.conf
+      sudo sysctl -p
+      # Kubeadm fails to reach kubelet metrics, because VMWare Guest Customization maps localhost to an
+      # IPv6 address (https://kb.vmware.com/s/article/83138), which does not resolve. This ensures localhost
+      # resolves to an IPv4 address.
+      sed -i 's/::1/127.0.0.1/g' /etc/hosts || true
       vmtoolsd --cmd "info-set guestinfo.postcustomization.networkconfiguration.status successful"
 
       # Our images do not ship the VCD metering service,
@@ -81,8 +91,6 @@ runcmd:
 - bash /root/bootstrap.sh
 timezone: UTC
 disable_root: false
-# Ensure we have an IPv4 address for localhost
-manage_etc_hosts: localhost
 # Ensure that cloud-init can override the hostname.
 preserve_hostname: false
 hostname: "{{ .MachineName }}"


### PR DESCRIPTION
## Description
In #11, I relied on cloud-init to ensure this mapping, but it looks like I misunderstood what cloud-init would do with the `manage_etc_hosts: localhost` configuration. It does _not_, surprisingly, map localhost to an IPv4 address.

This reverts to the original mechanism that ensures the mapping.